### PR TITLE
feat: Use npms.io instead of registry.npmjs.org

### DIFF
--- a/packages/playground/src/hooks/useNpmSearch.ts
+++ b/packages/playground/src/hooks/useNpmSearch.ts
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import useDebounce from "react-use/esm/useDebounce";
-import { NpmSearchResultItem, Searcher } from "../lib/npm/searcher";
+import { NpmSearchResultItem, Searcher } from "../lib/npm/searcher-npms";
 
 const perPage = 20;
 const searcher = new Searcher();

--- a/packages/playground/src/lib/npm/searcher-npms.ts
+++ b/packages/playground/src/lib/npm/searcher-npms.ts
@@ -1,0 +1,64 @@
+// Work around for "Registry API returns an incorrect version: 0.0.0"
+// https://npm.community/t/registry-api-returns-an-incorrect-version-0-0-0/7912/3
+
+export type NpmSearchResultUser = {
+  username: string;
+};
+
+export type NpmPackage = {
+  main: string;
+  typings: string;
+  types: string;
+};
+
+export type NpmPackageSummary = {
+  name: string;
+  scope: string;
+  version: string;
+  description: string;
+  date: string;
+  author: NpmSearchResultUser;
+  publisher: NpmSearchResultUser;
+  maintainers: NpmSearchResultUser[];
+  links: {
+    npm?: string;
+    repository?: string;
+  };
+};
+
+export type NpmSearchResultItem = {
+  package: NpmPackageSummary;
+  score: {
+    final: number;
+    detail: {
+      quality: number;
+      popularity: number;
+      maintenance: number;
+    };
+  };
+  searchScore: number;
+};
+
+export type NpmSearchResult = {
+  total: number;
+  objects: NpmSearchResultItem[];
+};
+
+export class Searcher {
+  async search(
+    query: string,
+    config: { page: number; perPage: number }
+  ): Promise<NpmSearchResult> {
+    const params = new URLSearchParams();
+    params.set("q", query);
+    params.set("size", String(config.perPage));
+    params.set("from", String(config.page * config.perPage));
+
+    // @ts-ignore npms returns `results` but we need compatible to npm registry API
+    const { results, total } = await fetch(
+      `https://api.npms.io/v2/search?${params.toString()}`
+    ).then(res => res.json() as Promise<NpmSearchResult>);
+
+    return { objects: results, total };
+  }
+}


### PR DESCRIPTION
> &mdash; [Registry API returns an incorrect version: 0.0.0 - 🐞 bugs - npm forum](https://npm.community/t/registry-api-returns-an-incorrect-version-0-0-0/7912/3)

> &mdash; [npms.io API documentation](https://api-docs.npms.io/)


npms.io works:

- exact match in short terms(we do not use unpkg.com to work around for exact match)
- returns correct version