### PR TITLE
Install dependencies recursively

### DIFF
--- a/packages/playground/src/lib/npm/resolver-enhanced.ts
+++ b/packages/playground/src/lib/npm/resolver-enhanced.ts
@@ -1,0 +1,108 @@
+// Exmerimental
+import * as path from "path";
+import {
+  createSourceFile,
+  CompilerOptions,
+  ScriptTarget,
+  SourceFile,
+  isExportDeclaration,
+  isImportDeclaration
+} from "typescript";
+import { NpmPackage } from "./searcher";
+import { UnPkg } from "../unpkg";
+import { traverse } from "../ast";
+
+export type Files = {
+  uri: string;
+  code: string;
+}[];
+
+const getEntryTypeFileName = (pkg: NpmPackage) => {
+  if (pkg.typings) {
+    return pkg.typings.replace(/^\.\//, "/");
+  }
+  if (pkg.types) {
+    if (pkg.types.endsWith(".d.ts")) {
+      return `/${pkg.types}`;
+    }
+    return `/${pkg.types}.d.ts`;
+  }
+
+  return "/" + pkg.main.replace(".js", ".d.ts").replace(/^\.\//, "/");
+};
+
+export class Resolver {
+  cache: Map<string, Files>;
+
+  constructor() {
+    this.cache = new Map();
+  }
+
+  async fetchFilesAll(
+    pkgs: { name: string; version: string }[],
+    compilerOptions: CompilerOptions
+  ): Promise<SourceFile[][]> {
+    return Promise.all(
+      pkgs.map(({ name, version }) => {
+        return this.fetchFiles(name, version, compilerOptions);
+      })
+    );
+  }
+
+  async fetchFiles(
+    name: string,
+    version: string,
+    compilerOptions: CompilerOptions
+  ): Promise<SourceFile[]> {
+    const unpkg = new UnPkg(name, version);
+    const pkgDetail = await unpkg.fetchAsJson<NpmPackage>("/package.json");
+    const entryTypePath = getEntryTypeFileName(pkgDetail);
+    const visited: SourceFile[] = [];
+    const open: string[] = [entryTypePath];
+
+    while (open.length) {
+      let node = open.shift()!;
+      if (visited.some(n => n.fileName === node)) {
+        continue;
+      }
+
+      const sourceFile = createSourceFile(
+        node,
+        await unpkg.fetchAsText(node),
+        compilerOptions.target || ScriptTarget.ES5
+      );
+
+      visited.push(sourceFile);
+      const referencePaths = sourceFile.referencedFiles.map(file => {
+        return path.resolve(path.dirname(node), file.fileName);
+      });
+
+      const importPaths: string[] = [];
+      traverse(sourceFile, n => {
+        if (!isImportDeclaration(n) && !isExportDeclaration(n)) {
+          return;
+        }
+        const { moduleSpecifier } = n;
+        if (!moduleSpecifier) {
+          return;
+        }
+
+        // @ts-ignore Property 'text' does not exist on type 'Expression'.
+        const specifier = moduleSpecifier.text;
+        if (!specifier.startsWith(".")) {
+          console.log(`TODO: Install npm module recursively: ${specifier}`);
+          return;
+        }
+
+        const _newFilePath = path.resolve(path.dirname(node), specifier);
+        const newFilePath = _newFilePath.endsWith(".d.ts")
+          ? _newFilePath
+          : _newFilePath + ".d.ts";
+        importPaths.push(newFilePath);
+      });
+      open.push(...referencePaths, ...importPaths);
+    }
+
+    return visited;
+  }
+}

--- a/packages/playground/src/lib/npm/resolver.ts
+++ b/packages/playground/src/lib/npm/resolver.ts
@@ -1,34 +1,46 @@
-import * as path from "path";
 import {
   createSourceFile,
   CompilerOptions,
   ScriptTarget,
-  SourceFile,
-  isExportDeclaration,
-  isImportDeclaration
+  SourceFile
 } from "typescript";
 import { NpmPackage } from "./searcher";
-import { UnPkg } from "../unpkg";
-import { traverse } from "../ast";
+import { UnPkg, MetaFile, MetaDirectry } from "../unpkg";
 
 export type Files = {
   uri: string;
   code: string;
 }[];
 
-const getEntryTypeFileName = (pkg: NpmPackage) => {
-  if (pkg.typings) {
-    return pkg.typings.replace(/^\.\//, "/");
-  }
-  if (pkg.types) {
-    if (pkg.types.endsWith(".d.ts")) {
-      return `/${pkg.types}`;
-    }
-    return `/${pkg.types}.d.ts`;
-  }
-
-  return "/" + pkg.main.replace(".js", ".d.ts").replace(/^\.\//, "/");
+const getTargetFiles = (entry: MetaDirectry) => {
+  const files: MetaFile[] = entry.files.flatMap(
+    (entry: MetaDirectry | MetaFile) =>
+      entry.type === "directory" ? getTargetFiles(entry) : entry
+  );
+  return files.filter(({ path }) => {
+    const extMatched = extensions.some(ext => path.endsWith(ext));
+    const inBlacklist = blackList.some(subStr => path.includes(subStr));
+    return extMatched && !inBlacklist;
+  });
 };
+
+const withRetry = <T = {}>(
+  fn: () => Promise<T>,
+  limit: number,
+  onError: (e: Error) => void = () => {}
+): Promise<T> => {
+  return fn().catch(e => {
+    onError(e);
+    if (limit === 0) {
+      throw e;
+    }
+
+    return withRetry(fn, limit - 1);
+  });
+};
+
+const blackList = ["package.json"];
+const extensions = [".ts", ".tsx", ".js", ".jsx"];
 
 export class Resolver {
   cache: Map<string, Files>;
@@ -51,57 +63,37 @@ export class Resolver {
   async fetchFiles(
     name: string,
     version: string,
-    compilerOptions: CompilerOptions
+    compilerOptions: CompilerOptions,
+    prefix = ""
   ): Promise<SourceFile[]> {
     const unpkg = new UnPkg(name, version);
-    const pkgDetail = await unpkg.fetchAsJson<NpmPackage>("/package.json");
-    const entryTypePath = getEntryTypeFileName(pkgDetail);
-    const visited: SourceFile[] = [];
-    const open: string[] = [entryTypePath];
+    const pkgJson = await unpkg.fetchAsJson<NpmPackage>("/package.json");
+    const fileTree = await unpkg.fetchFiles();
+    const files = getTargetFiles(fileTree);
 
-    while (open.length) {
-      let node = open.shift()!;
-      if (visited.some(n => n.fileName === node)) {
-        continue;
-      }
+    const dependencySourceFiles = await Promise.all(
+      Object.entries(pkgJson.dependencies || {}).map(([pkgName, semver]) =>
+        this.fetchFiles(
+          pkgName,
+          semver,
+          compilerOptions,
+          prefix + `/node_modules/${pkgName}`
+        )
+      )
+    );
 
-      const sourceFile = createSourceFile(
-        node,
-        await unpkg.fetchAsText(node),
-        compilerOptions.target || ScriptTarget.ES5
-      );
+    const sourceFiles = await Promise.all(
+      files.map(file =>
+        withRetry(() => unpkg.fetchAsText(file.path), 5).then(txt =>
+          createSourceFile(
+            prefix + file.path,
+            txt,
+            compilerOptions.target || ScriptTarget.ES5
+          )
+        )
+      )
+    );
 
-      visited.push(sourceFile);
-      const referencePaths = sourceFile.referencedFiles.map(file => {
-        return path.resolve(path.dirname(node), file.fileName);
-      });
-
-      const importPaths: string[] = [];
-      traverse(sourceFile, n => {
-        if (!isImportDeclaration(n) && !isExportDeclaration(n)) {
-          return;
-        }
-        const { moduleSpecifier } = n;
-        if (!moduleSpecifier) {
-          return;
-        }
-
-        // @ts-ignore Property 'text' does not exist on type 'Expression'.
-        const specifier = moduleSpecifier.text;
-        if (!specifier.startsWith(".")) {
-          console.log(`TODO: Install npm module recursively: ${specifier}`);
-          return;
-        }
-
-        const _newFilePath = path.resolve(path.dirname(node), specifier);
-        const newFilePath = _newFilePath.endsWith(".d.ts")
-          ? _newFilePath
-          : _newFilePath + ".d.ts";
-        importPaths.push(newFilePath);
-      });
-      open.push(...referencePaths, ...importPaths);
-    }
-
-    return visited;
+    return sourceFiles.concat(dependencySourceFiles.flat());
   }
 }

--- a/packages/playground/src/lib/npm/searcher.ts
+++ b/packages/playground/src/lib/npm/searcher.ts
@@ -6,6 +6,7 @@ export type NpmPackage = {
   main: string;
   typings: string;
   types: string;
+  dependencies: Record<string, string>;
 };
 
 export type NpmPackageSummary = {

--- a/packages/playground/src/lib/unpkg.ts
+++ b/packages/playground/src/lib/unpkg.ts
@@ -12,6 +12,20 @@ function _fetch(
   );
 }
 
+export type MetaFile = {
+  path: string;
+  type: "file";
+  contentType: string; // FIXME: more strictly
+  integrity: string;
+  lastModified: string;
+  size: number;
+};
+export type MetaDirectry = {
+  path: string;
+  type: "directory";
+  files: (MetaFile | MetaDirectry)[];
+};
+
 function fetchAsJson<T>(
   name: string,
   version: string,
@@ -37,5 +51,9 @@ export class UnPkg {
 
   fetchAsJson<T extends {} = {}>(path: string) {
     return fetchAsJson<T>(this.name, this.version, path);
+  }
+
+  fetchFiles(): Promise<MetaDirectry> {
+    return fetchAsJson<MetaDirectry>(this.name, this.version, "/?meta");
   }
 }


### PR DESCRIPTION
For example, `@types/react` depends on `csstype`.

Structure:

- `node_modules/@types/react/index.d.ts`
- `node_modules/@types/react/node_modules/csstype/indexd.ts`
